### PR TITLE
Add new target to enable PR workflows in fork

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: Lint
-on: [push, pull_request]
+on: [push, pull_request, pull_request_target]
 
 jobs:
   lint-markdown:


### PR DESCRIPTION
## Description

This PR adds a new target, `pull_request_target` that enables PR workflows in forks.

### Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Documentation

## Contributors

- @mariakimheinert 

## Reminder

All GitHub Actions checks must be in a passing state in this branch or fork before this pull request can be merged.
